### PR TITLE
Removing no needed dependencies

### DIFF
--- a/Doppler.ImageAnalyzer.Api/Doppler.ImageAnalyzer.Api.csproj
+++ b/Doppler.ImageAnalyzer.Api/Doppler.ImageAnalyzer.Api.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="AWSSDK.Rekognition" Version="3.7.102.46" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.103.16" />
     <PackageReference Include="MediatR" Version="12.0.1" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />


### PR DESCRIPTION
# Background

We removed no needed dependencies in the API project, specifically MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0

[Related Issue](https://github.com/FromDoppler/doppler-image-analysis-api/issues/53)