### PR TITLE
Dop 1354 log image analysis response using loggly

### DIFF
--- a/Doppler.ImageAnalyzer.Api/Controllers/ImageAnalyzerController.cs
+++ b/Doppler.ImageAnalyzer.Api/Controllers/ImageAnalyzerController.cs
@@ -8,9 +8,12 @@ namespace Doppler.ImageAnalyzer.Api.Controllers;
 [ApiController]
 public class ImageAnalyzerController : DopplerControllerBase
 {
-    public ImageAnalyzerController(IMediator mediator)
+    protected readonly ILogger<ImageAnalyzerController> _logger;
+
+    public ImageAnalyzerController(IMediator mediator, ILogger<ImageAnalyzerController> logger)
         : base(mediator)
     {
+        _logger = logger;
     }
 
     [HttpPost]
@@ -18,6 +21,8 @@ public class ImageAnalyzerController : DopplerControllerBase
     {
         var command = new AnalyzeHtmlCommand.Command { HtmlToAnalize = request.HtmlToAnalize, AnalysisType = request.AnalysisType };
         var response = await _mediator.Send(command, cancellationToken);
+
+        LogImageAnalysisResponse(response);
 
         return HandleResponse(response, "Returned image analysis");
     }
@@ -28,6 +33,31 @@ public class ImageAnalyzerController : DopplerControllerBase
         var command = new AnalyzeImageListCommand.Command { ImageUrls = request.ImageUrls, AnalysisType = request.AnalysisType };
         var response = await _mediator.Send(command, cancellationToken);
 
+        LogImageAnalysisResponse(response);
+
         return HandleResponse(response, "Returned image analysis");
+    }
+
+    private void LogImageAnalysisResponse(Response<List<ImageAnalysisResponse>> response)
+    {
+        if (response.IsSuccessStatusCode && response.Payload != null)
+        {
+            var imagesAnalysis = response.Payload;
+            _logger.LogInformation(
+                "Analisys Response => Status Code: {AnalysisResponse_StatusCode} - Number of Images: {AnalysisResponse_ImagesCount} - Analysis Result: {@AnalysisResponse_Result}",
+                (int)response.StatusCode,
+                imagesAnalysis.Count,
+                imagesAnalysis
+            );
+        }
+        else
+        {
+            _logger.LogInformation(
+                "Analisys Response => Status Code: {AnalysisResponse_StatusCode} - Title: {AnalysisResponse_ErrorTitle} - Exception Message: {AnalysisResponse_ExceptionMessage}",
+                (int)response.StatusCode,
+                response.ValidationIssue.Title,
+                response.ValidationIssue.ExceptionMessage
+            );
+        }
     }
 }

--- a/Doppler.ImageAnalyzer.Api/Doppler.ImageAnalyzer.Api.csproj
+++ b/Doppler.ImageAnalyzer.Api/Doppler.ImageAnalyzer.Api.csproj
@@ -15,6 +15,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.5" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Loggly" Version="5.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/Doppler.ImageAnalyzer.Api/Features/Analysis/Commands/AnalyzeImageList/AnalyzeImageListCommandHandler.cs
+++ b/Doppler.ImageAnalyzer.Api/Features/Analysis/Commands/AnalyzeImageList/AnalyzeImageListCommandHandler.cs
@@ -32,7 +32,7 @@ public partial class AnalyzeImageListCommand
 
                 if (request.ImageUrls.Count == 0)
                 {
-                    return Response.CreateBadRequestResponse<List<ImageAnalysisResponse>>("No valid imnage urls to process.");
+                    return Response.CreateBadRequestResponse<List<ImageAnalysisResponse>>("No valid image urls to process.");
                 }
 
                 var payload = await _analysisOrchestrator.ProcessImageList(request.ImageUrls, request.AnalysisType, cancellationToken);

--- a/Doppler.ImageAnalyzer.Api/Logging/LogglySetup.cs
+++ b/Doppler.ImageAnalyzer.Api/Logging/LogglySetup.cs
@@ -1,0 +1,32 @@
+using Loggly.Config;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace Doppler.ImageAnalyzer.Api.Logging
+{
+    public static class LogglySetup
+    {
+        private const string DefaultEndpointHostname = "logs-01.loggly.com";
+        private const int DefaultEndpointPort = 443;
+
+        public static IConfiguration ConfigureLoggly(
+            this IConfiguration configuration,
+            IHostEnvironment hostingEnvironment,
+            string appSettingsSection = nameof(LogglyConfig))
+        {
+            var config = LogglyConfig.Instance;
+
+            // Set default values
+            config.Transport.EndpointPort = DefaultEndpointPort;
+
+            // Bind values from configuration
+            configuration.GetSection(appSettingsSection).Bind(config);
+
+            // Configure convention values if not set in configuration
+            config.ApplicationName ??= hostingEnvironment.ApplicationName;
+            config.Transport.EndpointHostname ??= DefaultEndpointHostname;
+
+            return configuration;
+        }
+    }
+}

--- a/Doppler.ImageAnalyzer.Api/Logging/SerilogSetup.cs
+++ b/Doppler.ImageAnalyzer.Api/Logging/SerilogSetup.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+using System;
+
+namespace Doppler.ImageAnalyzer.Api.Logging
+{
+    public static class SerilogSetup
+    {
+        public static LoggerConfiguration SetupSeriLog(
+            this LoggerConfiguration loggerConfiguration,
+            IConfiguration configuration,
+            IHostEnvironment hostEnvironment)
+        {
+            configuration.ConfigureLoggly(hostEnvironment);
+
+            loggerConfiguration
+                .WriteTo.Console()
+                .Enrich.WithProperty("Application", hostEnvironment.ApplicationName)
+                .Enrich.WithProperty("Environment", hostEnvironment.EnvironmentName)
+                .Enrich.WithProperty("Platform", Environment.OSVersion.Platform)
+                .Enrich.WithProperty("Runtime", Environment.Version)
+                .Enrich.WithProperty("OSVersion", Environment.OSVersion)
+                .Enrich.FromLogContext()
+                .ReadFrom.Configuration(configuration);
+
+            if (!hostEnvironment.IsDevelopment())
+            {
+                loggerConfiguration
+                    .WriteTo.Loggly();
+            }
+
+            return loggerConfiguration;
+        }
+    }
+}

--- a/Doppler.ImageAnalyzer.Api/Program.cs
+++ b/Doppler.ImageAnalyzer.Api/Program.cs
@@ -1,4 +1,6 @@
+using Doppler.ImageAnalyzer.Api.Logging;
 using Microsoft.OpenApi.Models;
+using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Configuration.AddEnvironmentVariables();
@@ -40,6 +42,10 @@ builder.Services.AddSwaggerGen(c =>
 });
 builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<Program>());
 builder.Services.AddOperationsLogic(appConfig);
+builder.Host.UseSerilog((hostContext, loggerConfiguration) =>
+{
+    loggerConfiguration.SetupSeriLog(hostContext.Configuration, hostContext.HostingEnvironment);
+});
 
 var app = builder.Build();
 

--- a/Doppler.ImageAnalyzer.Api/appsettings.Development.json
+++ b/Doppler.ImageAnalyzer.Api/appsettings.Development.json
@@ -1,8 +1,11 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Information",
+        "Microsoft.Hosting.Lifetime": "Information"
+      }
     }
   },
   "AppConfiguration": {

--- a/Doppler.ImageAnalyzer.Api/appsettings.json
+++ b/Doppler.ImageAnalyzer.Api/appsettings.json
@@ -1,10 +1,14 @@
 {
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    "MinimumLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning",
-      "Microsoft.AspNetCore.DataProtection": "Information"
+      "Override": {
+        "Microsoft": "Warning"
+      }
     }
+  },
+  "LogglyConfig": {
+    "CustomerToken": "REPLACE_WITH_CUSTOMER_TOKEN"
   },
   "AllowedHosts": "*",
   "AppConfiguration": {

--- a/Doppler.ImageAnalyzer.UnitTests/Api/Controllers/ImageAnalyzerControllerTests.cs
+++ b/Doppler.ImageAnalyzer.UnitTests/Api/Controllers/ImageAnalyzerControllerTests.cs
@@ -1,12 +1,16 @@
-﻿namespace Doppler.ImageAnalyzer.UnitTests.Api.Controllers;
+﻿using Microsoft.Extensions.Logging;
+
+namespace Doppler.ImageAnalyzer.UnitTests.Api.Controllers;
 
 public class ImageAnalyzerControllerTests
 {
     private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<ILogger<ImageAnalyzerController>> _loggerMock;
 
     public ImageAnalyzerControllerTests()
     {
         _mediatorMock = new Mock<IMediator>();
+        _loggerMock = new Mock<ILogger<ImageAnalyzerController>>();
     }
 
     [Fact]
@@ -17,7 +21,7 @@ public class ImageAnalyzerControllerTests
         _mediatorMock.Setup(m => m.Send(It.IsAny<IRequest<Response<List<ImageAnalysisResponse>>>>(), default))
                      .ReturnsAsync(new Response<List<ImageAnalysisResponse>>());
 
-        var controller = new ImageAnalyzerController(_mediatorMock.Object);
+        var controller = new ImageAnalyzerController(_mediatorMock.Object, _loggerMock.Object);
         var request = new AnalyzeHtmlRequest { HtmlToAnalize = html, AnalysisType = "ModerationContent" };
 
         var result = await controller.AnalyzeHtml(request, default);
@@ -35,7 +39,7 @@ public class ImageAnalyzerControllerTests
         _mediatorMock.Setup(m => m.Send(It.IsAny<IRequest<Response<List<ImageAnalysisResponse>>>>(), default))
                      .ReturnsAsync(new Response<List<ImageAnalysisResponse>> { StatusCode = HttpStatusCode.BadRequest });
 
-        var controller = new ImageAnalyzerController(_mediatorMock.Object);
+        var controller = new ImageAnalyzerController(_mediatorMock.Object, _loggerMock.Object);
         var request = new AnalyzeHtmlRequest { HtmlToAnalize = html, AnalysisType = "ModerationContent" };
 
         var result = await controller.AnalyzeHtml(request, default);
@@ -55,7 +59,7 @@ public class ImageAnalyzerControllerTests
         _mediatorMock.Setup(m => m.Send(It.IsAny<IRequest<Response<List<ImageAnalysisResponse>>>>(), default))
                      .ReturnsAsync(new Response<List<ImageAnalysisResponse>>());
 
-        var controller = new ImageAnalyzerController(_mediatorMock.Object);
+        var controller = new ImageAnalyzerController(_mediatorMock.Object, _loggerMock.Object);
         var request = new AnalyzeImageListRequest { ImageUrls = imageUrls, AnalysisType = "ModerationContent" };
 
         var result = await controller.AnalyzeImageList(request, default);
@@ -74,7 +78,7 @@ public class ImageAnalyzerControllerTests
         _mediatorMock.Setup(m => m.Send(It.IsAny<IRequest<Response<List<ImageAnalysisResponse>>>>(), default))
                      .ReturnsAsync(new Response<List<ImageAnalysisResponse>> { StatusCode = HttpStatusCode.BadRequest });
 
-        var controller = new ImageAnalyzerController(_mediatorMock.Object);
+        var controller = new ImageAnalyzerController(_mediatorMock.Object, _loggerMock.Object);
         var request = new AnalyzeImageListRequest { ImageUrls = imageUrls, AnalysisType = "ModerationContent" };
 
         var result = await controller.AnalyzeImageList(request, default);


### PR DESCRIPTION
- add Serilog and Loggly
- add logging for the images analysis results:

Properties logged to take advantage in the Loggly app: 
- {AnalysisResponse_StatusCode}: filter by analysis success or with errors.
- {AnalysisResponse_ImagesCount}: understanding the number of images that have the analysis done.
- {AnalysisResponse_ErrorTitle}: understanding the errors happened in the analysis done.
- {AnalysisResponse_ExceptionMessage}: similar to previous.

**TODO:** configure Loggly customer key in the [doppler-swarm repository](https://github.com/MakingSense/doppler-swarm)