### PR TITLE
Dop 1478 return idresult after analyze

### DIFF
--- a/Doppler.ImageAnalyzer.Api/Controllers/ImageAnalyzerController.cs
+++ b/Doppler.ImageAnalyzer.Api/Controllers/ImageAnalyzerController.cs
@@ -43,11 +43,19 @@ public class ImageAnalyzerController : DopplerControllerBase
 
     private async Task<string> SaveResultsAsync(Response<List<ImageAnalysisResponse>> response)
     {
-        string resultId = "";
+        string resultId = string.Empty;
+
         if (response.IsSuccessStatusCode && response.Payload != null)
         {
-            var imagesAnalysis = response.Payload;
-            resultId = await _imageAnalysisResultService.SaveAsync(imagesAnalysis);
+            try
+            {
+                var imagesAnalysis = response.Payload;
+                resultId = await _imageAnalysisResultService.SaveAsync(imagesAnalysis);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected failure saving analysis response.");
+            }
         }
         else
         {

--- a/Doppler.ImageAnalyzer.Api/Controllers/ImageAnalyzerController.cs
+++ b/Doppler.ImageAnalyzer.Api/Controllers/ImageAnalyzerController.cs
@@ -17,25 +17,41 @@ public class ImageAnalyzerController : DopplerControllerBase
     }
 
     [HttpPost]
-    public async Task<ActionResult<Response<List<ImageAnalysisResponse>>>> AnalyzeHtml(AnalyzeHtmlRequest request, CancellationToken cancellationToken)
+    public async Task<ActionResult<Response<AnalysisResultResponse>>> AnalyzeHtml(AnalyzeHtmlRequest request, CancellationToken cancellationToken)
     {
         var command = new AnalyzeHtmlCommand.Command { HtmlToAnalize = request.HtmlToAnalize, AnalysisType = request.AnalysisType };
         var response = await _mediator.Send(command, cancellationToken);
 
         LogImageAnalysisResponse(response);
 
-        return HandleResponse(response, "Returned image analysis");
+        return HandleResponse(mapImageAnalysisResponseList(response), "Returned image analysis");
     }
 
     [HttpPost]
-    public async Task<ActionResult<Response<List<ImageAnalysisResponse>>>> AnalyzeImageList(AnalyzeImageListRequest request, CancellationToken cancellationToken)
+    public async Task<ActionResult<Response<AnalysisResultResponse>>> AnalyzeImageList(AnalyzeImageListRequest request, CancellationToken cancellationToken)
     {
         var command = new AnalyzeImageListCommand.Command { ImageUrls = request.ImageUrls, AnalysisType = request.AnalysisType };
         var response = await _mediator.Send(command, cancellationToken);
 
         LogImageAnalysisResponse(response);
 
-        return HandleResponse(response, "Returned image analysis");
+        return HandleResponse(mapImageAnalysisResponseList(response), "Returned image analysis");
+    }
+
+    private Response<AnalysisResultResponse> mapImageAnalysisResponseList(Response<List<ImageAnalysisResponse>> response)
+    {
+        return new Response<AnalysisResultResponse>()
+        {
+            StatusCode = response.StatusCode,
+            ValidationIssue = response.ValidationIssue,
+            Payload = response.Payload == null ?
+                null :
+                new AnalysisResultResponse()
+                {
+                    AnalysisResult = response.Payload,
+                    AnalysisResultId = "abc", // TODO: replace harcoded AnalysisResultId by id obtained from db
+                }
+        };
     }
 
     private void LogImageAnalysisResponse(Response<List<ImageAnalysisResponse>> response)

--- a/Doppler.ImageAnalyzer.Api/Features/Analysis/Responses/AnalysisResultResponse.cs
+++ b/Doppler.ImageAnalyzer.Api/Features/Analysis/Responses/AnalysisResultResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace Doppler.ImageAnalyzer.Api.Features.Analysis.Responses
+{
+    public class AnalysisResultResponse
+    {
+        public List<ImageAnalysisResponse>? AnalysisResult { get; set; }
+        public string? AnalysisResultId { get; set; }
+    }
+}

--- a/Doppler.ImageAnalyzer.Api/Services/Repositories/Entities/ImageAnalysisResultDocumentInfo.cs
+++ b/Doppler.ImageAnalyzer.Api/Services/Repositories/Entities/ImageAnalysisResultDocumentInfo.cs
@@ -8,9 +8,6 @@
         // Props at root level
         public const string Id_PropName = "_id";
         public const string ImagesCount_PropName = "imagesCount";
-        public const string StatusCode_PropName = "statusCode";
-        public const string ErrorTitle_PropName = "errorTitle";
-        public const string ExceptionMessage_PropName = "exceptionMessage";
         public const string Result_PropName = "result";
 
         // Props at Result level

--- a/Doppler.ImageAnalyzer.Api/Services/Repositories/Entities/ImageAnalysisResultEntitySerializer.cs
+++ b/Doppler.ImageAnalyzer.Api/Services/Repositories/Entities/ImageAnalysisResultEntitySerializer.cs
@@ -4,16 +4,13 @@ namespace Doppler.ImageAnalyzer.Api.Services.Repositories.Entities
 {
     public static class ImageAnalysisResultEntitySerializer
     {
-        public static BsonDocument SerializeToBsonDocument(this List<ImageAnalysisResponse>? results, ObjectId _id, int statusCode, string? errorTitle, string? exceptionMessage)
+        public static BsonDocument SerializeToBsonDocument(this List<ImageAnalysisResponse>? results, ObjectId _id)
         {
             return new BsonDocument
                 {
                     { ImageAnalysisResultDocumentInfo.Id_PropName, _id },
                     { ImageAnalysisResultDocumentInfo.Result_PropName, results != null ? results.SerializeToBsonArray() : BsonNull.Value },
                     { ImageAnalysisResultDocumentInfo.ImagesCount_PropName, results != null ? results.Count : 0 },
-                    { ImageAnalysisResultDocumentInfo.StatusCode_PropName, statusCode },
-                    { ImageAnalysisResultDocumentInfo.ErrorTitle_PropName, !string.IsNullOrEmpty(errorTitle) ? errorTitle : BsonNull.Value },
-                    { ImageAnalysisResultDocumentInfo.ExceptionMessage_PropName, !string.IsNullOrEmpty(exceptionMessage) ? exceptionMessage : BsonNull.Value },
                 };
         }
 

--- a/Doppler.ImageAnalyzer.Api/Services/Repositories/ImageAnalysisResultMongoDBRepository.cs
+++ b/Doppler.ImageAnalyzer.Api/Services/Repositories/ImageAnalysisResultMongoDBRepository.cs
@@ -15,11 +15,11 @@ namespace Doppler.ImageAnalyzer.Api.Services.Repositories
             _collection = database.GetCollection<BsonDocument>(ImageAnalysisResultDocumentInfo.CollectionName);
         }
 
-        public async Task<string> SaveAsync(int statusCode, List<ImageAnalysisResponse>? imageAnalysisResultList, string? errorTitle, string? exceptionMessage)
+        public async Task<string> SaveAsync(List<ImageAnalysisResponse>? imageAnalysisResultList)
         {
             ObjectId _id = ObjectId.GenerateNewId();
 
-            var imageAnalysisResultDocument = imageAnalysisResultList.SerializeToBsonDocument(_id, statusCode, errorTitle, exceptionMessage);
+            var imageAnalysisResultDocument = imageAnalysisResultList.SerializeToBsonDocument(_id);
             await _collection.InsertOneAsync(document: imageAnalysisResultDocument);
 
             return _id.ToString();

--- a/Doppler.ImageAnalyzer.Api/Services/Repositories/Interfaces/IImageAnalysisResultRepository.cs
+++ b/Doppler.ImageAnalyzer.Api/Services/Repositories/Interfaces/IImageAnalysisResultRepository.cs
@@ -2,6 +2,6 @@
 {
     public interface IImageAnalysisResultRepository
     {
-        Task<string> SaveAsync(int statusCode, List<ImageAnalysisResponse>? imageAnalysisResult, string? errorTitle, string? exceptionMessage);
+        Task<string> SaveAsync(List<ImageAnalysisResponse>? imageAnalysisResult);
     }
 }

--- a/Doppler.ImageAnalyzer.Api/Services/Repositories/RepositoryServiceExtensions.cs
+++ b/Doppler.ImageAnalyzer.Api/Services/Repositories/RepositoryServiceExtensions.cs
@@ -30,11 +30,6 @@ namespace Doppler.ImageAnalyzer.Api.Services.Repositories
 
                 var imageAnalysisResult_Collection = database.GetCollection<BsonDocument>(ImageAnalysisResultDocumentInfo.CollectionName);
 
-                var imageAnalysisResult_StatusCode_Index = new CreateIndexModel<BsonDocument>(
-                    Builders<BsonDocument>.IndexKeys.Ascending(ImageAnalysisResultDocumentInfo.StatusCode_PropName)
-                );
-                imageAnalysisResult_Collection.Indexes.CreateOne(imageAnalysisResult_StatusCode_Index);
-
                 var imageAnalysisResult_ImagesCount_Index = new CreateIndexModel<BsonDocument>(
                     Builders<BsonDocument>.IndexKeys.Ascending(ImageAnalysisResultDocumentInfo.ImagesCount_PropName)
                 );

--- a/Doppler.ImageAnalyzer.UnitTests/Api/Controllers/ImageAnalyzerControllerTests.cs
+++ b/Doppler.ImageAnalyzer.UnitTests/Api/Controllers/ImageAnalyzerControllerTests.cs
@@ -53,6 +53,52 @@ public class ImageAnalyzerControllerTests
     }
 
     [Fact]
+    public async Task AnalyzeHtml_ShouldCallImageAnalysisResultRepositoryAndReturnResultId_WhenSuccess()
+    {
+        // Arrange
+        var html = "<html><div><img src='https://www.test.com/test.jpg'></div></html>";
+
+        var response = new Response<List<ImageAnalysisResponse>>()
+        {
+            Payload = new List<ImageAnalysisResponse>()
+            {
+                new ImageAnalysisResponse()
+                {
+                    ImageUrl = "https://www.test.com/test.jpg",
+                    AnalysisDetail = new List<ImageAnalysisDetailResponse>(),
+                }
+            }
+        };
+
+        var saveAsyncResultId = "aResultId";
+
+        _mediatorMock.Setup(m => m.Send(It.IsAny<IRequest<Response<List<ImageAnalysisResponse>>>>(), default))
+                     .ReturnsAsync(response);
+
+        _imageAnalysisResultRepositoryMock.Setup(m => m.SaveAsync(It.IsAny<List<ImageAnalysisResponse>>()))
+                     .ReturnsAsync(saveAsyncResultId);
+
+        var controller = new ImageAnalyzerController(_mediatorMock.Object, _loggerMock.Object, _imageAnalysisResultRepositoryMock.Object);
+        var request = new AnalyzeHtmlRequest { HtmlToAnalize = html, AnalysisType = "ModerationContent" };
+
+        // Act
+        var result = await controller.AnalyzeHtml(request, default);
+
+        // Assert
+        Assert.NotNull(result);
+        _imageAnalysisResultRepositoryMock.Verify(x => x.SaveAsync(It.IsAny<List<ImageAnalysisResponse>>()), Times.Once());
+
+        // Obtain the result of the call
+        var callResult = Assert.IsType<Microsoft.AspNetCore.Mvc.OkObjectResult>(result.Result);
+
+        // Obtain "Value" and convert to "AnalysisResultResponse"
+        var analysisResultResponse = Assert.IsType<AnalysisResultResponse>(callResult.Value);
+
+        // Assert the result contains the "AnalysisResultId" returned by the Repository
+        Assert.True(analysisResultResponse.AnalysisResultId == saveAsyncResultId);
+    }
+
+    [Fact]
     public async Task AnalyzeImageList_ShouldCallMediator_WhenSuccess()
     {
         var imageUrls = new List<string>{

--- a/Doppler.ImageAnalyzer.UnitTests/Api/Controllers/ImageAnalyzerControllerTests.cs
+++ b/Doppler.ImageAnalyzer.UnitTests/Api/Controllers/ImageAnalyzerControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using Doppler.ImageAnalyzer.Api.Services.Repositories.Interfaces;
+using Microsoft.Extensions.Logging;
 
 namespace Doppler.ImageAnalyzer.UnitTests.Api.Controllers;
 
@@ -6,11 +7,13 @@ public class ImageAnalyzerControllerTests
 {
     private readonly Mock<IMediator> _mediatorMock;
     private readonly Mock<ILogger<ImageAnalyzerController>> _loggerMock;
+    private readonly Mock<IImageAnalysisResultRepository> _imageAnalysisResultRepositoryMock;
 
     public ImageAnalyzerControllerTests()
     {
         _mediatorMock = new Mock<IMediator>();
         _loggerMock = new Mock<ILogger<ImageAnalyzerController>>();
+        _imageAnalysisResultRepositoryMock = new Mock<IImageAnalysisResultRepository>();
     }
 
     [Fact]
@@ -21,7 +24,7 @@ public class ImageAnalyzerControllerTests
         _mediatorMock.Setup(m => m.Send(It.IsAny<IRequest<Response<List<ImageAnalysisResponse>>>>(), default))
                      .ReturnsAsync(new Response<List<ImageAnalysisResponse>>());
 
-        var controller = new ImageAnalyzerController(_mediatorMock.Object, _loggerMock.Object);
+        var controller = new ImageAnalyzerController(_mediatorMock.Object, _loggerMock.Object, _imageAnalysisResultRepositoryMock.Object);
         var request = new AnalyzeHtmlRequest { HtmlToAnalize = html, AnalysisType = "ModerationContent" };
 
         var result = await controller.AnalyzeHtml(request, default);
@@ -39,7 +42,7 @@ public class ImageAnalyzerControllerTests
         _mediatorMock.Setup(m => m.Send(It.IsAny<IRequest<Response<List<ImageAnalysisResponse>>>>(), default))
                      .ReturnsAsync(new Response<List<ImageAnalysisResponse>> { StatusCode = HttpStatusCode.BadRequest });
 
-        var controller = new ImageAnalyzerController(_mediatorMock.Object, _loggerMock.Object);
+        var controller = new ImageAnalyzerController(_mediatorMock.Object, _loggerMock.Object, _imageAnalysisResultRepositoryMock.Object);
         var request = new AnalyzeHtmlRequest { HtmlToAnalize = html, AnalysisType = "ModerationContent" };
 
         var result = await controller.AnalyzeHtml(request, default);
@@ -59,7 +62,7 @@ public class ImageAnalyzerControllerTests
         _mediatorMock.Setup(m => m.Send(It.IsAny<IRequest<Response<List<ImageAnalysisResponse>>>>(), default))
                      .ReturnsAsync(new Response<List<ImageAnalysisResponse>>());
 
-        var controller = new ImageAnalyzerController(_mediatorMock.Object, _loggerMock.Object);
+        var controller = new ImageAnalyzerController(_mediatorMock.Object, _loggerMock.Object, _imageAnalysisResultRepositoryMock.Object);
         var request = new AnalyzeImageListRequest { ImageUrls = imageUrls, AnalysisType = "ModerationContent" };
 
         var result = await controller.AnalyzeImageList(request, default);
@@ -78,7 +81,7 @@ public class ImageAnalyzerControllerTests
         _mediatorMock.Setup(m => m.Send(It.IsAny<IRequest<Response<List<ImageAnalysisResponse>>>>(), default))
                      .ReturnsAsync(new Response<List<ImageAnalysisResponse>> { StatusCode = HttpStatusCode.BadRequest });
 
-        var controller = new ImageAnalyzerController(_mediatorMock.Object, _loggerMock.Object);
+        var controller = new ImageAnalyzerController(_mediatorMock.Object, _loggerMock.Object, _imageAnalysisResultRepositoryMock.Object);
         var request = new AnalyzeImageListRequest { ImageUrls = imageUrls, AnalysisType = "ModerationContent" };
 
         var result = await controller.AnalyzeImageList(request, default);

--- a/Doppler.ImageAnalyzer.UnitTests/Api/Controllers/ImageAnalyzerControllerTests.cs
+++ b/Doppler.ImageAnalyzer.UnitTests/Api/Controllers/ImageAnalyzerControllerTests.cs
@@ -99,6 +99,60 @@ public class ImageAnalyzerControllerTests
     }
 
     [Fact]
+    public async Task AnalyzeHtml_ShouldLogErrorAndReturnEmptyResultId_WhenImageAnalysisResultRepositoryThrowException()
+    {
+        // Arrange
+        var html = "<html><div><img src='https://www.test.com/test.jpg'></div></html>";
+
+        var response = new Response<List<ImageAnalysisResponse>>()
+        {
+            Payload = new List<ImageAnalysisResponse>()
+            {
+                new ImageAnalysisResponse()
+                {
+                    ImageUrl = "https://www.test.com/test.jpg",
+                    AnalysisDetail = new List<ImageAnalysisDetailResponse>(),
+                }
+            }
+        };
+
+        _mediatorMock.Setup(m => m.Send(It.IsAny<IRequest<Response<List<ImageAnalysisResponse>>>>(), default))
+                     .ReturnsAsync(response);
+
+        _imageAnalysisResultRepositoryMock.Setup(m => m.SaveAsync(It.IsAny<List<ImageAnalysisResponse>>()))
+                     .ThrowsAsync(new Exception());
+
+        var controller = new ImageAnalyzerController(_mediatorMock.Object, _loggerMock.Object, _imageAnalysisResultRepositoryMock.Object);
+        var request = new AnalyzeHtmlRequest { HtmlToAnalize = html, AnalysisType = "ModerationContent" };
+
+        // Act
+        var result = await controller.AnalyzeHtml(request, default);
+
+        // Assert
+        Assert.NotNull(result);
+        _imageAnalysisResultRepositoryMock.Verify(x => x.SaveAsync(It.IsAny<List<ImageAnalysisResponse>>()), Times.Once());
+        _loggerMock.Verify(
+            x => x.Log(
+                It.Is<LogLevel>(l => l == LogLevel.Error),
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString() == "Unexpected failure saving analysis response."),
+                It.IsAny<Exception>(),
+                It.Is<Func<It.IsAnyType, Exception?, string>>((v, t) => true)
+                ),
+            Times.Once
+        );
+
+        // Obtain the result of the call
+        var callResult = Assert.IsType<Microsoft.AspNetCore.Mvc.OkObjectResult>(result.Result);
+
+        // Obtain "Value" and convert to "AnalysisResultResponse"
+        var analysisResultResponse = Assert.IsType<AnalysisResultResponse>(callResult.Value);
+
+        // Assert the result contains an Empty "AnalysisResultId"
+        Assert.True(analysisResultResponse.AnalysisResultId == string.Empty);
+    }
+
+    [Fact]
     public async Task AnalyzeImageList_ShouldCallMediator_WhenSuccess()
     {
         var imageUrls = new List<string>{

--- a/Doppler.ImageAnalyzer.UnitTests/Api/Services/Respositories/ImageAnalysisResultMongoDBRepositoryTest.cs
+++ b/Doppler.ImageAnalyzer.UnitTests/Api/Services/Respositories/ImageAnalysisResultMongoDBRepositoryTest.cs
@@ -32,7 +32,7 @@ namespace Doppler.ImageAnalyzer.UnitTests.Api.Services.Repositories
 
             // Act
             // Assert
-            var result = await Assert.ThrowsAsync<Exception>(() => sut.SaveAsync(200, new List<ImageAnalysisResponse>(), null, null));
+            var result = await Assert.ThrowsAsync<Exception>(() => sut.SaveAsync(new List<ImageAnalysisResponse>()));
         }
 
         [Fact]
@@ -71,7 +71,7 @@ namespace Doppler.ImageAnalyzer.UnitTests.Api.Services.Repositories
             var sut = CreateSut(mockMongoDatabase.Object);
 
             // Act
-            await sut.SaveAsync(200, imageAnalysisResponse, null, null);
+            await sut.SaveAsync(imageAnalysisResponse);
 
             // Assert
             mockMongoCollection.Verify(


### PR DESCRIPTION
**BREAKING CHANGE** ‼️

**Objective**: return the `AnalysisResultId` when the Analysis is **OK**, and save it on the DB.

**Considerations**:
- avoid storing the Analysis with errors in the DB. When an analysis has errors, they will be logged with **Loggly** (just as right now)
- according to the above point, the `statusCode`, `errorTitle`, and `exceptionMessage` fields were removed from the collection.
- the structure of the result with errors remains the same
- now, the result OK has the following structure:
```
{
  analysisResult: [...],
  analysisResultId: "resultId",
}
```