### PR TITLE
Dop 1479 fix mongodb indexes creation

### DIFF
--- a/Doppler.ImageAnalyzer.Api/Services/Repositories/RepositoryServiceExtensions.cs
+++ b/Doppler.ImageAnalyzer.Api/Services/Repositories/RepositoryServiceExtensions.cs
@@ -22,28 +22,28 @@ namespace Doppler.ImageAnalyzer.Api.Services.Repositories
 
             var mongoUrl = mongoUrlBuilder.ToMongoUrl();
             var mongoClient = new MongoClient(mongoUrl);
-            var database = mongoClient.GetDatabase(mongoUrl.DatabaseName);
 
-            services.AddSingleton<IMongoClient>(x =>
+            services.AddSingleton<IMongoClient>(mongoClient);
+            services.AddSingleton(x =>
             {
-                #region ImageAnalysisResult_Indexes
-
-                var imageAnalysisResult_Collection = database.GetCollection<BsonDocument>(ImageAnalysisResultDocumentInfo.CollectionName);
-
-                var imageAnalysisResult_ImagesCount_Index = new CreateIndexModel<BsonDocument>(
-                    Builders<BsonDocument>.IndexKeys.Ascending(ImageAnalysisResultDocumentInfo.ImagesCount_PropName)
-                );
-                imageAnalysisResult_Collection.Indexes.CreateOne(imageAnalysisResult_ImagesCount_Index);
-
-                #endregion
-
-                return mongoClient;
+                var database = mongoClient.GetDatabase(mongoUrl.DatabaseName);
+                CreateMongoDBIndexes(database);
+                return database;
             });
-            services.AddSingleton(x => mongoClient.GetDatabase(mongoUrl.DatabaseName));
 
             services.AddSingleton<IImageAnalysisResultRepository, ImageAnalysisResultMongoDBRepository>();
 
             return services;
+        }
+
+        private static void CreateMongoDBIndexes(IMongoDatabase database)
+        {
+            var imageAnalysisResult_Collection = database.GetCollection<BsonDocument>(ImageAnalysisResultDocumentInfo.CollectionName);
+
+            var imageAnalysisResult_ImagesCount_Index = new CreateIndexModel<BsonDocument>(
+                Builders<BsonDocument>.IndexKeys.Ascending(ImageAnalysisResultDocumentInfo.ImagesCount_PropName)
+            );
+            imageAnalysisResult_Collection.Indexes.CreateOne(imageAnalysisResult_ImagesCount_Index);
         }
     }
 }

--- a/Doppler.ImageAnalyzer.UnitTests/Api/Http/PlaygroundApplication.cs
+++ b/Doppler.ImageAnalyzer.UnitTests/Api/Http/PlaygroundApplication.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using MongoDB.Driver;
 
 namespace Doppler.ImageAnalyzer.UnitTests.Api.Http;
 
@@ -19,6 +21,11 @@ class PlaygroundApplication : WebApplicationFactory<Program>
         builder.ConfigureServices(services =>
         {
             // TODO: Add mock/test services to the builder here
+            services.AddSingleton(x =>
+            {
+                Mock<IMongoDatabase> mockMongoDatabase = new Mock<IMongoDatabase>();
+                return mockMongoDatabase.Object;
+            });
         });
 
         return base.CreateHost(builder);


### PR DESCRIPTION
Fix the Mongodb indexes creation.
The defined indexes were not being created because the code in the lambda function was not being executed.